### PR TITLE
#23 Update Kubernetes registry configuration and fix registry domain typo

### DIFF
--- a/k8s.md
+++ b/k8s.md
@@ -76,7 +76,9 @@ By default we install the CLI image in namespace `scone-tools`. You can overwrit
 export CLI_NAMESPACE="..."
 ```
 
-Next we create a Kubernetes namespace and pull secrets. We assume here that we can use the same PAT for different pull secrets. Please adjust in case you use a unique PAT for each pull secret: 
+Next we create a Kubernetes namespace and pull secrets. We assume here that we can use the same PAT for different pull secrets. Please adjust in case you use a unique PAT for each pull secret.
+
+Also, in case you built and pushed the image to a different registry, you need to adjust the value for `docker-server` in the  `docker-registry` secret accordingly.
 
 ```bash
 export CLI_NAMESPACE=${CLI_NAMESPACE:-scone-tools}

--- a/k8s.md
+++ b/k8s.md
@@ -33,7 +33,7 @@ kubectl get nodes || { echo "Failed to list Kubernetes nodes: Exiting" ; exit 1;
 
 ## Deployment
 
-You need to login to the docker registry `registry.scontain.yom` with an account that has access to the namespace `scone.cloud`. If you are already logged in to `registry.scontain.yom`, you are all set. If you have not logged in yet, please set the following variables:
+You need to login to the docker registry `registry.scontain.com` with an account that has access to the namespace `scone.cloud`. If you are already logged in to `registry.scontain.com`, you are all set. If you have not logged in yet, please set the following variables:
 
 ```
 export SCONE_REGISTRY_USERNAME="..." # set to your user name 


### PR DESCRIPTION
This pull request addresses the following:

- **Registry Configuration Guidance:** Added instructions to correctly adjust the `docker-server` value in the `docker-registry` secret when using custom registries, helping users avoid deployment issues.
- **Typographical Fix:** Corrected the docker registry domain in deployment instructions from `registry.scontain.yom` to `registry.scontain.com` to enhance accuracy and prevent confusion.