### PR TITLE
Install scone-glibc in sconecli flow

### DIFF
--- a/docs/install_sconecli.sh
+++ b/docs/install_sconecli.sh
@@ -354,6 +354,22 @@ pe "$(cat <<'EOF'
 EOF
 )"
 pe "$(cat <<'EOF'
+export SCONE_GLIBC_DEB=$(docker export scone-packages | tar -t | grep -i "glibc.*installer" | sort -V | tail -1 | xargs basename)
+EOF
+)"
+pe "$(cat <<'EOF'
+[[ -n "$SCONE_GLIBC_DEB" ]] || { echo "Failed to locate scone-glibc installer in $REPO/$IMAGE:$SCONE_VERSION"; exit 1; }
+EOF
+)"
+pe "$(cat <<'EOF'
+docker cp "scone-packages:/$SCONE_GLIBC_DEB" /tmp/
+EOF
+)"
+pe "$(cat <<'EOF'
+
+EOF
+)"
+pe "$(cat <<'EOF'
 docker rm scone-packages
 EOF
 )"
@@ -375,6 +391,10 @@ EOF
 )"
 pe "$(cat <<'EOF'
 sudo dpkg -i /tmp/packages/scone-cli_amd64.deb 
+EOF
+)"
+pe "$(cat <<'EOF'
+sudo dpkg -i "/tmp/$SCONE_GLIBC_DEB"
 EOF
 )"
 pe "$(cat <<'EOF'
@@ -411,6 +431,10 @@ EOF
 )"
 pe "$(cat <<'EOF'
 rm -rf /tmp/scone-bin
+EOF
+)"
+pe "$(cat <<'EOF'
+rm -f "/tmp/$SCONE_GLIBC_DEB"
 EOF
 )"
 

--- a/docs/install_sconecli.sh
+++ b/docs/install_sconecli.sh
@@ -330,23 +330,19 @@ pe "$(cat <<'EOF'
 EOF
 )"
 pe "$(cat <<'EOF'
+    docker cp scone-packages:/scone-td-build.deb /tmp/scone-bin/;
+EOF
+)"
+pe "$(cat <<'EOF'
+    docker cp scone-packages:/kubectl-scone.deb /tmp/scone-bin/;
+EOF
+)"
+pe "$(cat <<'EOF'
+    docker cp scone-packages:/kubectl-scone-azure.deb /tmp/scone-bin/;
+EOF
+)"
+pe "$(cat <<'EOF'
 }
-EOF
-)"
-pe "$(cat <<'EOF'
-
-EOF
-)"
-pe "$(cat <<'EOF'
-docker cp scone-packages:/usr/local/bin/scone-td-build /tmp/scone-bin/ || echo "ERROR: 'scone-td-build' not available"
-EOF
-)"
-pe "$(cat <<'EOF'
-docker cp scone-packages:/usr/local/bin/kubectl-scone /tmp/scone-bin/ || echo "ERROR: 'kubectl scone' not available"
-EOF
-)"
-pe "$(cat <<'EOF'
-docker cp scone-packages:/usr/local/bin/kubectl-scone-azure /tmp/scone-bin/  || echo "ERROR: 'kubectl-scone-azure' not available"
 EOF
 )"
 pe "$(cat <<'EOF'

--- a/sconecli.md
+++ b/sconecli.md
@@ -120,12 +120,17 @@ docker cp scone-packages:/usr/local/bin/scone-td-build /tmp/scone-bin/ || echo "
 docker cp scone-packages:/usr/local/bin/kubectl-scone /tmp/scone-bin/ || echo "ERROR: 'kubectl scone' not available"
 docker cp scone-packages:/usr/local/bin/kubectl-scone-azure /tmp/scone-bin/  || echo "ERROR: 'kubectl-scone-azure' not available"
 
+export SCONE_GLIBC_DEB=$(docker export scone-packages | tar -t | grep -i "glibc.*installer" | sort -V | tail -1 | xargs basename)
+[[ -n "$SCONE_GLIBC_DEB" ]] || { echo "Failed to locate scone-glibc installer in $REPO/$IMAGE:$SCONE_VERSION"; exit 1; }
+docker cp "scone-packages:/$SCONE_GLIBC_DEB" /tmp/
+
 docker rm scone-packages
 
 # install the packages
 sudo dpkg -i /tmp/packages/scone-common_amd64.deb 
 sudo dpkg -i /tmp/packages/scone-libc_amd64.deb 
 sudo dpkg -i /tmp/packages/scone-cli_amd64.deb 
+sudo dpkg -i "/tmp/$SCONE_GLIBC_DEB"
 
 # install binaries on host
 sudo install -m 0755 /tmp/scone-bin/scone-td-build /usr/local/bin/scone-td-build  || echo "ERROR: 'scone-td-build' not available"
@@ -135,6 +140,7 @@ sudo install -m 0755 /tmp/scone-bin/kubectl-scone-azure /usr/local/bin/kubectl-s
 # clean up
 rm -rf /tmp/packages
 rm -rf /tmp/scone-bin
+rm -f "/tmp/$SCONE_GLIBC_DEB"
 ```
 
 We ensure that `kubectl-scone` plugin only exists once - otherwise, `kubectl` issues a warning:

--- a/sconecli.md
+++ b/sconecli.md
@@ -114,11 +114,10 @@ docker cp scone-packages:/packages /tmp || {
     docker cp scone-packages:/scone-common_amd64.deb /tmp/packages;
     docker cp scone-packages:/scone-libc_amd64.deb /tmp/packages;
     docker cp scone-packages:/scone-cli_amd64.deb /tmp/packages;
+    docker cp scone-packages:/scone-td-build.deb /tmp/scone-bin/;
+    docker cp scone-packages:/kubectl-scone.deb /tmp/scone-bin/;
+    docker cp scone-packages:/kubectl-scone-azure.deb /tmp/scone-bin/;
 }
-
-docker cp scone-packages:/usr/local/bin/scone-td-build /tmp/scone-bin/ || echo "ERROR: 'scone-td-build' not available"
-docker cp scone-packages:/usr/local/bin/kubectl-scone /tmp/scone-bin/ || echo "ERROR: 'kubectl scone' not available"
-docker cp scone-packages:/usr/local/bin/kubectl-scone-azure /tmp/scone-bin/  || echo "ERROR: 'kubectl-scone-azure' not available"
 
 export SCONE_GLIBC_DEB=$(docker export scone-packages | tar -t | grep -i "glibc.*installer" | sort -V | tail -1 | xargs basename)
 [[ -n "$SCONE_GLIBC_DEB" ]] || { echo "Failed to locate scone-glibc installer in $REPO/$IMAGE:$SCONE_VERSION"; exit 1; }

--- a/scripts/install_sconecli.sh
+++ b/scripts/install_sconecli.sh
@@ -190,11 +190,10 @@ printf '%s\n' 'docker cp scone-packages:/packages /tmp || {'
 printf '%s\n' '    docker cp scone-packages:/scone-common_amd64.deb /tmp/packages;'
 printf '%s\n' '    docker cp scone-packages:/scone-libc_amd64.deb /tmp/packages;'
 printf '%s\n' '    docker cp scone-packages:/scone-cli_amd64.deb /tmp/packages;'
+printf '%s\n' '    docker cp scone-packages:/scone-td-build.deb /tmp/scone-bin/;'
+printf '%s\n' '    docker cp scone-packages:/kubectl-scone.deb /tmp/scone-bin/;'
+printf '%s\n' '    docker cp scone-packages:/kubectl-scone-azure.deb /tmp/scone-bin/;'
 printf '%s\n' '}'
-printf '%s\n' ''
-printf '%s\n' 'docker cp scone-packages:/usr/local/bin/scone-td-build /tmp/scone-bin/ || echo "ERROR: '\''scone-td-build'\'' not available"'
-printf '%s\n' 'docker cp scone-packages:/usr/local/bin/kubectl-scone /tmp/scone-bin/ || echo "ERROR: '\''kubectl scone'\'' not available"'
-printf '%s\n' 'docker cp scone-packages:/usr/local/bin/kubectl-scone-azure /tmp/scone-bin/  || echo "ERROR: '\''kubectl-scone-azure'\'' not available"'
 printf '%s\n' ''
 printf '%s\n' 'export SCONE_GLIBC_DEB=$(docker export scone-packages | tar -t | grep -i "glibc.*installer" | sort -V | tail -1 | xargs basename)'
 printf '%s\n' '[[ -n "$SCONE_GLIBC_DEB" ]] || { echo "Failed to locate scone-glibc installer in $REPO/$IMAGE:$SCONE_VERSION"; exit 1; }'
@@ -226,11 +225,10 @@ docker cp scone-packages:/packages /tmp || {
     docker cp scone-packages:/scone-common_amd64.deb /tmp/packages;
     docker cp scone-packages:/scone-libc_amd64.deb /tmp/packages;
     docker cp scone-packages:/scone-cli_amd64.deb /tmp/packages;
+    docker cp scone-packages:/scone-td-build.deb /tmp/scone-bin/;
+    docker cp scone-packages:/kubectl-scone.deb /tmp/scone-bin/;
+    docker cp scone-packages:/kubectl-scone-azure.deb /tmp/scone-bin/;
 }
-
-docker cp scone-packages:/usr/local/bin/scone-td-build /tmp/scone-bin/ || echo "ERROR: 'scone-td-build' not available"
-docker cp scone-packages:/usr/local/bin/kubectl-scone /tmp/scone-bin/ || echo "ERROR: 'kubectl scone' not available"
-docker cp scone-packages:/usr/local/bin/kubectl-scone-azure /tmp/scone-bin/  || echo "ERROR: 'kubectl-scone-azure' not available"
 
 export SCONE_GLIBC_DEB=$(docker export scone-packages | tar -t | grep -i "glibc.*installer" | sort -V | tail -1 | xargs basename)
 [[ -n "$SCONE_GLIBC_DEB" ]] || { echo "Failed to locate scone-glibc installer in $REPO/$IMAGE:$SCONE_VERSION"; exit 1; }

--- a/scripts/install_sconecli.sh
+++ b/scripts/install_sconecli.sh
@@ -196,12 +196,17 @@ printf '%s\n' 'docker cp scone-packages:/usr/local/bin/scone-td-build /tmp/scone
 printf '%s\n' 'docker cp scone-packages:/usr/local/bin/kubectl-scone /tmp/scone-bin/ || echo "ERROR: '\''kubectl scone'\'' not available"'
 printf '%s\n' 'docker cp scone-packages:/usr/local/bin/kubectl-scone-azure /tmp/scone-bin/  || echo "ERROR: '\''kubectl-scone-azure'\'' not available"'
 printf '%s\n' ''
+printf '%s\n' 'export SCONE_GLIBC_DEB=$(docker export scone-packages | tar -t | grep -i "glibc.*installer" | sort -V | tail -1 | xargs basename)'
+printf '%s\n' '[[ -n "$SCONE_GLIBC_DEB" ]] || { echo "Failed to locate scone-glibc installer in $REPO/$IMAGE:$SCONE_VERSION"; exit 1; }'
+printf '%s\n' 'docker cp "scone-packages:/$SCONE_GLIBC_DEB" /tmp/'
+printf '%s\n' ''
 printf '%s\n' 'docker rm scone-packages'
 printf '%s\n' ''
 printf '%s\n' '# install the packages'
 printf '%s\n' 'sudo dpkg -i /tmp/packages/scone-common_amd64.deb '
 printf '%s\n' 'sudo dpkg -i /tmp/packages/scone-libc_amd64.deb '
 printf '%s\n' 'sudo dpkg -i /tmp/packages/scone-cli_amd64.deb '
+printf '%s\n' 'sudo dpkg -i "/tmp/$SCONE_GLIBC_DEB"'
 printf '%s\n' ''
 printf '%s\n' '# install binaries on host'
 printf '%s\n' 'sudo install -m 0755 /tmp/scone-bin/scone-td-build /usr/local/bin/scone-td-build  || echo "ERROR: '\''scone-td-build'\'' not available"'
@@ -211,6 +216,7 @@ printf '%s\n' ''
 printf '%s\n' '# clean up'
 printf '%s\n' 'rm -rf /tmp/packages'
 printf '%s\n' 'rm -rf /tmp/scone-bin'
+printf '%s\n' 'rm -f "/tmp/$SCONE_GLIBC_DEB"'
 printf "${RESET}"
 
 # copy Debian packages and required binaries
@@ -226,12 +232,17 @@ docker cp scone-packages:/usr/local/bin/scone-td-build /tmp/scone-bin/ || echo "
 docker cp scone-packages:/usr/local/bin/kubectl-scone /tmp/scone-bin/ || echo "ERROR: 'kubectl scone' not available"
 docker cp scone-packages:/usr/local/bin/kubectl-scone-azure /tmp/scone-bin/  || echo "ERROR: 'kubectl-scone-azure' not available"
 
+export SCONE_GLIBC_DEB=$(docker export scone-packages | tar -t | grep -i "glibc.*installer" | sort -V | tail -1 | xargs basename)
+[[ -n "$SCONE_GLIBC_DEB" ]] || { echo "Failed to locate scone-glibc installer in $REPO/$IMAGE:$SCONE_VERSION"; exit 1; }
+docker cp "scone-packages:/$SCONE_GLIBC_DEB" /tmp/
+
 docker rm scone-packages
 
 # install the packages
 sudo dpkg -i /tmp/packages/scone-common_amd64.deb 
 sudo dpkg -i /tmp/packages/scone-libc_amd64.deb 
 sudo dpkg -i /tmp/packages/scone-cli_amd64.deb 
+sudo dpkg -i "/tmp/$SCONE_GLIBC_DEB"
 
 # install binaries on host
 sudo install -m 0755 /tmp/scone-bin/scone-td-build /usr/local/bin/scone-td-build  || echo "ERROR: 'scone-td-build' not available"
@@ -241,6 +252,7 @@ sudo install -m 0755 /tmp/scone-bin/kubectl-scone-azure /usr/local/bin/kubectl-s
 # clean up
 rm -rf /tmp/packages
 rm -rf /tmp/scone-bin
+rm -f "/tmp/$SCONE_GLIBC_DEB"
 
 printf "${VIOLET}"
 printf '%s\n' ''


### PR DESCRIPTION
Resolves #53 and #54

---

<!-- status write-up (auto) -->
# Current status

Implemented and approved. Installs `scone-glibc` in the sconecli installer flow (`scripts/install_sconecli.sh`, `docs/install_sconecli.sh`, `sconecli.md`; +47/-12), resolving #53 and #54. The PR is **approved** and **mergeable** (mergeStateStatus CLEAN) — despite the board's "Blocked" label there is no open git/review blocker. Confirm any external blocker, then merge. (Limited context on this `scone`-repo change — please sanity-check.)

# Steps to completion

- Confirm there is no remaining external blocker (the board says Blocked, but the PR is approved + clean + mergeable).
- Merge.

# Acceptance criteria

- [x] scone-glibc installed and used by the sconecli flow
- [x] PR approved and mergeable (no open git/review blocker)
- [ ] #53 and #54 resolved (on merge)
- [ ] Merged
