### PR TITLE
k8s_cli.sh: installAdd a possibility to user-provide CLI_NAMESPACE via env var

### DIFF
--- a/k8s.md
+++ b/k8s.md
@@ -80,7 +80,7 @@ export CLI_IMAGE="${CLI_IMAGE:-registry.scontain.com/workshop/scone}"
 By default we install the CLI image in namespace `scone-tools`. You can overwrite the namespace with the help of environment variable `CLI_NAMESPACE`:
 
 ```bash
-export CLI_NAMESPACE="scone-tools"
+export CLI_NAMESPACE="${CLI_NAMESPACE:-scone-tools}"
 ```
 
 Let's ask the user and set the environment variables depending on the input of the user:

--- a/scripts/k8s_cli.sh
+++ b/scripts/k8s_cli.sh
@@ -142,10 +142,10 @@ printf '%s\n' ''
 printf "${RESET}"
 
 printf "${ORANGE}"
-printf '%s\n' 'export CLI_NAMESPACE="scone-tools"'
+printf '%s\n' 'CLI_NAMESPACE="${CLI_NAMESPACE:-scone-tools}"'
 printf "${RESET}"
 
-export CLI_NAMESPACE="scone-tools"
+export CLI_NAMESPACE="${CLI_NAMESPACE:-scone-tools}"
 
 printf "${VIOLET}"
 printf '%s\n' ''


### PR DESCRIPTION
In the script `scripts/k8s_cli.sh` it is currently not possible to provide a value for `CLI_NAMESPACE` via environment variable. However, the docstring explicitly mentions the possibility to provide a user-specified value. This PR simply adapts the setup of `CLI_IMAGE` for `CLI_NAMESPACE`